### PR TITLE
Implement board chat

### DIFF
--- a/client/src/api/chat-messages.js
+++ b/client/src/api/chat-messages.js
@@ -1,0 +1,31 @@
+import socket from './socket';
+
+export const transformChatMessage = (message) => ({
+  ...message,
+  ...(message.createdAt && { createdAt: new Date(message.createdAt) }),
+});
+
+const getChatMessages = (boardId, data, headers) =>
+  socket.get(`/boards/${boardId}/chat-messages`, data, headers).then((body) => ({
+    ...body,
+    items: body.items.map(transformChatMessage),
+  }));
+
+const createChatMessage = (boardId, data, headers) =>
+  socket.post(`/boards/${boardId}/chat-messages`, data, headers).then((body) => ({
+    ...body,
+    item: transformChatMessage(body.item),
+  }));
+
+const makeHandleChatMessageCreate = (next) => (body) => {
+  next({
+    ...body,
+    item: transformChatMessage(body.item),
+  });
+};
+
+export default {
+  getChatMessages,
+  createChatMessage,
+  makeHandleChatMessageCreate,
+};

--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -29,6 +29,7 @@ import comments from './comments';
 import activities from './activities';
 import notifications from './notifications';
 import notificationServices from './notification-services';
+import chatMessages from './chat-messages';
 
 export { http, socket };
 
@@ -57,4 +58,5 @@ export default {
   ...activities,
   ...notifications,
   ...notificationServices,
+  ...chatMessages,
 };

--- a/client/src/components/boards/Board/Board.jsx
+++ b/client/src/components/boards/Board/Board.jsx
@@ -14,6 +14,7 @@ import FiniteContent from './FiniteContent';
 import EndlessContent from './EndlessContent';
 import CardModal from '../../cards/CardModal';
 import BoardActivitiesModal from '../../activities/BoardActivitiesModal';
+import Chat from '../../chat';
 
 const Board = React.memo(() => {
   const board = useSelector(selectors.selectCurrentBoard);
@@ -54,6 +55,7 @@ const Board = React.memo(() => {
   return (
     <>
       <Content />
+      <Chat />
       {modalNode}
     </>
   );

--- a/client/src/components/chat/Chat.jsx
+++ b/client/src/components/chat/Chat.jsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState, useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { Input, Button } from 'semantic-ui-react';
+
+import selectors from '../../selectors';
+import api, { socket } from '../../api';
+
+import styles from './Chat.module.scss';
+
+const Chat = React.memo(() => {
+  const boardId = useSelector((state) => selectors.selectCurrentBoard(state).id);
+  const currentUser = useSelector(selectors.selectCurrentUser);
+
+  const [messages, setMessages] = useState([]);
+  const [text, setText] = useState('');
+
+  useEffect(() => {
+    let isMounted = true;
+    api.getChatMessages(boardId).then(({ items }) => {
+      if (isMounted) {
+        setMessages(items);
+      }
+    });
+    const handleCreate = ({ item }) => {
+      setMessages((prev) => [...prev, item]);
+    };
+    socket.on('chatMessageCreate', handleCreate);
+    return () => {
+      isMounted = false;
+      socket.off('chatMessageCreate', handleCreate);
+    };
+  }, [boardId]);
+
+  const handleSubmit = useCallback(() => {
+    if (!text.trim()) {
+      return;
+    }
+    api.createChatMessage(boardId, { text }).catch(() => {});
+    setText('');
+  }, [boardId, text]);
+
+  return (
+    <div className={styles.chat}>
+      <div className={styles.messages}>
+        {messages.map((m) => (
+          <div key={m.id} className={styles.message}>
+            <b>{m.user.name}</b>: {m.text}
+          </div>
+        ))}
+      </div>
+      <Input
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            handleSubmit();
+          }
+        }}
+        placeholder="Say something"
+        action={<Button content="Send" onClick={handleSubmit} />}
+        className={styles.input}
+      />
+    </div>
+  );
+});
+
+export default Chat;

--- a/client/src/components/chat/Chat.module.scss
+++ b/client/src/components/chat/Chat.module.scss
@@ -1,0 +1,24 @@
+:global(#app) {
+  .chat {
+    margin-top: 14px;
+  }
+
+  .messages {
+    max-height: 200px;
+    overflow-y: auto;
+    margin-bottom: 8px;
+    padding: 4px;
+    border: 1px solid rgba(9, 30, 66, 0.13);
+    border-radius: 3px;
+    background: #fff;
+  }
+
+  .message {
+    margin-bottom: 4px;
+    word-break: break-word;
+  }
+
+  .input {
+    width: 100%;
+  }
+}

--- a/client/src/components/chat/index.js
+++ b/client/src/components/chat/index.js
@@ -1,0 +1,3 @@
+import Chat from './Chat';
+
+export default Chat;

--- a/server/api/controllers/chat-messages/create.js
+++ b/server/api/controllers/chat-messages/create.js
@@ -1,0 +1,36 @@
+const { idInput } = require('../../../utils/inputs');
+
+module.exports = {
+  inputs: {
+    boardId: { ...idInput, required: true },
+    text: { type: 'string', required: true, maxLength: 1024 },
+  },
+
+  async fn(inputs) {
+    const { currentUser } = this.req;
+
+    const board = await Board.qm.getOneById(inputs.boardId);
+    if (!board) {
+      throw { boardNotFound: 'Board not found' };
+    }
+
+    const boardMembership = await BoardMembership.qm.getOneByBoardIdAndUserId(board.id, currentUser.id);
+    if (!boardMembership) {
+      throw { boardNotFound: 'Board not found' }; // Forbidden
+    }
+
+    const message = {
+      id: Date.now(),
+      boardId: board.id,
+      user: sails.helpers.users.presentOne(currentUser, currentUser),
+      text: inputs.text,
+      createdAt: new Date(),
+    };
+
+    sails.hooks['chat-messages'].addMessage(message);
+
+    sails.sockets.broadcast(`board:${board.id}`, 'chatMessageCreate', { item: message }, this.req);
+
+    return { item: message };
+  },
+};

--- a/server/api/controllers/chat-messages/index.js
+++ b/server/api/controllers/chat-messages/index.js
@@ -1,0 +1,18 @@
+const { idInput } = require('../../../utils/inputs');
+
+module.exports = {
+  inputs: {
+    boardId: { ...idInput, required: true },
+  },
+
+  async fn(inputs) {
+    const board = await Board.qm.getOneById(inputs.boardId);
+    if (!board) {
+      throw { boardNotFound: 'Board not found' };
+    }
+
+    const messages = sails.hooks['chat-messages'].getMessages(board.id);
+
+    return { items: messages };
+  },
+};

--- a/server/api/hooks/chat-messages/index.js
+++ b/server/api/hooks/chat-messages/index.js
@@ -1,0 +1,21 @@
+module.exports = function defineChatMessagesHook(sails) {
+  const messagesByBoardId = new Map();
+  return {
+    initialize(cb) {
+      sails.log.info('Initializing custom hook (`chat-messages`)');
+      return cb();
+    },
+    addMessage(message) {
+      const boardId = message.boardId;
+      const arr = messagesByBoardId.get(boardId) || [];
+      arr.push(message);
+      if (arr.length > 50) {
+        arr.shift();
+      }
+      messagesByBoardId.set(boardId, arr);
+    },
+    getMessages(boardId) {
+      return messagesByBoardId.get(boardId) || [];
+    },
+  };
+};

--- a/server/config/routes.js
+++ b/server/config/routes.js
@@ -163,6 +163,9 @@ module.exports.routes = {
   'PATCH /api/comments/:id': 'comments/update',
   'DELETE /api/comments/:id': 'comments/delete',
 
+  'GET /api/boards/:boardId/chat-messages': 'chat-messages/index',
+  'POST /api/boards/:boardId/chat-messages': 'chat-messages/create',
+
   'GET /api/boards/:boardId/actions': 'actions/index-in-board',
   'GET /api/cards/:cardId/actions': 'actions/index-in-card',
 


### PR DESCRIPTION
## Summary
- add simple in-memory chat hook for boards
- expose chat APIs and routes
- create Chat component and API client
- show Chat component on board pages

## Testing
- `npm test` *(fails: mocha not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e48ea0a4832bae1a173d2631ba64